### PR TITLE
Also define the SCM_VERSION from git describe for prx_main.c

### DIFF
--- a/bld/src/proxyd/CMakeLists.txt
+++ b/bld/src/proxyd/CMakeLists.txt
@@ -8,7 +8,20 @@ compileAsC99()
 #
 add_executable(proxyd ${_PROJECT_ROOT}/src/prx_main.c)
 
-    target_link_libraries(proxyd libproxy)
+# Try to define the version from the closest parent git tag and
+# the current Git hash.
+find_package(Git)
+if(GIT_EXECUTABLE)
+	execute_process(
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMAND "${GIT_EXECUTABLE}" describe --always --tags --dirty
+    OUTPUT_VARIABLE GIT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  target_compile_definitions(proxyd PRIVATE SCM_VERSION="${GIT_VERSION}")
+endif()
+
+target_link_libraries(proxyd libproxy)
 if(${use_zlog})
     target_link_libraries(proxyd libzlog)
 endif()


### PR DESCRIPTION
The macro SCM_VERSION was not defined from `git describe`.
Which is changed by this pull request.

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>