### PR TITLE
Fix IOCP crash (#61)

### DIFF
--- a/api/csharp/proxy-api-csharp.sln
+++ b/api/csharp/proxy-api-csharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.Azure.Devices.Proxy.Samples", "Microsoft.Azure.Devices.Proxy.Samples", "{F78C9A16-78B2-4100-BB38-3889C17D6D01}"
 EndProject
@@ -155,8 +155,8 @@ Global
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net45.ActiveCfg = Debug|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net45.Build.0 = Debug|Any CPU
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net46.ActiveCfg = Debug|net46
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net46.Build.0 = Debug|net46
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net46.ActiveCfg = Debug|Any CPU
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|net46.Build.0 = Debug|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|x64.Build.0 = Debug|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -165,8 +165,8 @@ Global
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|Any CPU.Build.0 = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net45.ActiveCfg = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net45.Build.0 = Release|Any CPU
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net46.ActiveCfg = Debug|net46
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net46.Build.0 = Debug|net46
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net46.ActiveCfg = Release|Any CPU
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|net46.Build.0 = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|x64.ActiveCfg = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|x64.Build.0 = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Perf|x86.ActiveCfg = Signed|Any CPU
@@ -175,8 +175,8 @@ Global
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net45.ActiveCfg = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net45.Build.0 = Release|Any CPU
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net46.ActiveCfg = Release|net46
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net46.Build.0 = Release|net46
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net46.ActiveCfg = Release|Any CPU
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|net46.Build.0 = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|x64.ActiveCfg = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|x64.Build.0 = Release|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Release|x86.ActiveCfg = Release|Any CPU
@@ -185,8 +185,8 @@ Global
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|Any CPU.Build.0 = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net45.ActiveCfg = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net45.Build.0 = Signed|Any CPU
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net46.ActiveCfg = Signed|net46
-		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net46.Build.0 = Signed|net46
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net46.ActiveCfg = Signed|Any CPU
+		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|net46.Build.0 = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|x64.ActiveCfg = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|x64.Build.0 = Signed|Any CPU
 		{88811AFB-D7C4-AB5A-B1DE-955407F90D1B}.Signed|x86.ActiveCfg = Signed|Any CPU

--- a/src/io_token.c
+++ b/src/io_token.c
@@ -16,7 +16,7 @@
 #if !defined(DEBUG)
 #define DEFAULT_RENEWAL_TIMEOUT_SEC 8 * 60 * 60
 #else
-#define DEFAULT_RENEWAL_TIMEOUT_SEC     30 * 60
+#define DEFAULT_RENEWAL_TIMEOUT_SEC      30
 #endif // !defined(DEBUG)
 
 //

--- a/src/io_token.c
+++ b/src/io_token.c
@@ -14,9 +14,9 @@
 #include "azure_c_shared_utility/buffer_.h"
 
 #if !defined(DEBUG)
-#define DEFAULT_RENEWAL_TIMEOUT_SEC 8 * 60 * 60
+#define DEFAULT_RENEWAL_TIMEOUT_SEC (8 * 60 * 60)
 #else
-#define DEFAULT_RENEWAL_TIMEOUT_SEC      5 * 60
+#define DEFAULT_RENEWAL_TIMEOUT_SEC      (5 * 60)
 #endif // !defined(DEBUG)
 
 //

--- a/src/io_token.c
+++ b/src/io_token.c
@@ -16,7 +16,7 @@
 #if !defined(DEBUG)
 #define DEFAULT_RENEWAL_TIMEOUT_SEC 8 * 60 * 60
 #else
-#define DEFAULT_RENEWAL_TIMEOUT_SEC      30
+#define DEFAULT_RENEWAL_TIMEOUT_SEC      5 * 60
 #endif // !defined(DEBUG)
 
 //

--- a/src/prx_buffer.c
+++ b/src/prx_buffer.c
@@ -453,6 +453,8 @@ static int32_t prx_dynamic_buffer_set_size(
     chk_arg_fault_return(*buffer);
 
     orig = __prx_buffer(*buffer);
+    if (orig->length == size)
+        return er_ok;
     dbg_assert_buf(orig);
 
     // Pointers will change after realloc, so remove from checked out list

--- a/src/xio_sk.c
+++ b/src/xio_sk.c
@@ -290,7 +290,10 @@ static void xio_socket_on_end_receive(
     buffer = io_queue_buffer_from_ptr(*buf);
     dbg_assert_ptr(buffer);
 
-    if (result != er_ok && result != er_aborted && result != er_retry)
+    if (result != er_ok &&
+        result != er_aborted &&
+        result != er_retry &&
+        result != er_closed)
     {
         log_error(sk->log, "Error during pal receive (%s).",
             prx_err_string(result));


### PR DESCRIPTION
This should address #61 by essentially having close wait for pending flag to be cleared, signaling completion of the IOCP callback rather than checking whether the OVERLAPPED has completed, which does not ensure the callback has completed.  Originally it erroneously checked whether the buffer pointer was NULL to cover this case, now it correctly checks the "pending" flag.  This however exposed several other issues: a) open_ov was always pending after open, thus it could never close b) on mqtt disconnect recv always returns success, 0 bytes read (== remote side closed), pretty much continuously for which the xio_sk allocates then a 64 k buffer to read into (IOCP semantics on windows), which it tries to reallocate to 0, which fails, and thus during close memory consumption spiked.  A follow up might be to see if we should limit the buffer sizes for xio_sk to e.g. 4k, but we should do some measurements as to max buffer for mqtt...